### PR TITLE
Fix: use id instead of aid

### DIFF
--- a/sorting_hat_step/step.py
+++ b/sorting_hat_step/step.py
@@ -3,11 +3,9 @@ from db_plugins.db.mongo.connection import DatabaseConnection
 from survey_parser_plugins import ALeRCEParser
 from typing import List
 
-from sorting_hat_step.utils.database import db_queries
 from .utils import wizard, parser
 import logging
 import pandas as pd
-from operator import itemgetter
 
 
 class SortingHatStep(GenericStep):
@@ -22,9 +20,6 @@ class SortingHatStep(GenericStep):
         self.driver = db_connection
         self.driver.connect(config["DB_CONFIG"])
         self.parser = ALeRCEParser()
-        self.oid_query, self.conesearch_query = itemgetter(
-            "oid_query", "conesearch_query"
-        )(db_queries(self.driver))
 
     def pre_produce(self, result: pd.DataFrame):
         """
@@ -86,8 +81,8 @@ class SortingHatStep(GenericStep):
         # Internal cross-match that identifies same objects in own batch: create a new column named 'tmp_id'
         alerts = wizard.internal_cross_match(alerts)
         # Interaction with database: group all alerts with the same tmp_id and find/create alerce_id
-        alerts = wizard.find_existing_id(alerts, self.oid_query)
-        alerts = wizard.find_id_by_conesearch(alerts, self.conesearch_query)
+        alerts = wizard.find_existing_id(self.driver, alerts)
+        alerts = wizard.find_id_by_conesearch(self.driver, alerts)
         alerts = wizard.generate_new_id(alerts)
         alerts.drop(columns=["tmp_id"])
         return alerts

--- a/sorting_hat_step/step.py
+++ b/sorting_hat_step/step.py
@@ -84,5 +84,5 @@ class SortingHatStep(GenericStep):
         alerts = wizard.find_existing_id(self.driver, alerts)
         alerts = wizard.find_id_by_conesearch(self.driver, alerts)
         alerts = wizard.generate_new_id(alerts)
-        alerts.drop(columns=["tmp_id"])
+        alerts.drop(columns=["tmp_id"], inplace=True)
         return alerts

--- a/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/utils/database.py
@@ -21,7 +21,9 @@ def oid_query(db: DatabaseConnection, oid: list) -> Union[int, None]:
     return None
 
 
-def conesearch_query(db: DatabaseConnection, ra: float, dec: float, radius: float) -> List[dict]:
+def conesearch_query(
+    db: DatabaseConnection, ra: float, dec: float, radius: float
+) -> List[dict]:
     """
     Query the database and check if there is an alerce_id
     for the specified coordinates and search radius

--- a/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/utils/database.py
@@ -1,7 +1,54 @@
+import math
 from typing import Callable, Dict, List, Union
-from db_plugins.db.mongo.connection import DatabaseConnection
 
+from db_plugins.db.mongo.connection import DatabaseConnection
 from db_plugins.db.mongo.models import Object
+
+
+def oid_query(db: DatabaseConnection, oid: list) -> Union[int, None]:
+    """
+    Query the database and check if any of the OIDs is already in database
+
+    :param db: Database connection
+    :param oid: oid of any survey
+
+    :return: existing aid if exists else is None
+    """
+    mongo_query = db.query(Object)
+    found = mongo_query.find_one({"oid": {"$in": oid}}, {"_id": "aid"})
+    if found:
+        return found["aid"]
+    return None
+
+
+def conesearch_query(db: DatabaseConnection, ra: float, dec: float, radius: float) -> List[dict]:
+    """
+    Query the database and check if there is an alerce_id
+    for the specified coordinates and search radius
+
+    :param db: Database connection
+    :param ra: first coordinate argument (RA)
+    :param dec: first coordinate argument (Dec)
+    :param radius: search radius (arcsec)
+
+    :return: existing aid if exists else is None
+    """
+    mongo_query = db.query(Object)
+    cursor = mongo_query.collection.find(
+        {
+            "loc": {
+                "$geoWithin": {
+                    "$centerSphere": [
+                        [ra - 180, dec],
+                        math.radians(radius / 3600),
+                    ]
+                }
+            },
+        },
+        {"_id": "aid"},  # rename _id to aid
+    )
+    spatial = [i for i in cursor]
+    return spatial
 
 
 def db_queries(db: DatabaseConnection) -> Dict[str, Callable]:

--- a/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/utils/database.py
@@ -15,7 +15,7 @@ def oid_query(db: DatabaseConnection, oid: list) -> Union[int, None]:
     :return: existing aid if exists else is None
     """
     mongo_query = db.query(Object)
-    found = mongo_query.find_one({"oid": {"$in": oid}}, {"_id": "aid"})
+    found = mongo_query.collection.find_one({"oid": {"$in": oid}}, {"_id": "aid"})
     if found:
         return found["aid"]
     return None

--- a/sorting_hat_step/utils/wizard.py
+++ b/sorting_hat_step/utils/wizard.py
@@ -145,7 +145,9 @@ def find_existing_id(db: DatabaseConnection, alerts: pd.DataFrame):
     if not len(alerts_wo_aid.index):
         return alerts
     for tmp_id, group in alerts_wo_aid.groupby("tmp_id"):
-        alerts_wo_aid.loc[group.index, "aid"] = oid_query(db, group["oid"].unique().tolist())
+        alerts_wo_aid.loc[group.index, "aid"] = oid_query(
+            db, group["oid"].unique().tolist()
+        )
     alerts.loc[alerts_wo_aid.index, "aid"] = alerts_wo_aid["aid"]
     return alerts
 

--- a/tests/unittest/test_step.py
+++ b/tests/unittest/test_step.py
@@ -38,12 +38,16 @@ class SortingHatStepTestCase(unittest.TestCase):
         del self.step
 
     @mock.patch("sorting_hat_step.step.SortingHatStep._add_metrics")
-    def test_execute(self, _):
+    @mock.patch("sorting_hat_step.utils.wizard.oid_query")
+    def test_execute(self, mock_query, _):
         alerts = generate_alerts_batch(100)
+        mock_query.return_value = "aid"
         result = self.step.execute(alerts)
-        assert result["aid"] is not None
+        assert "aid" in result
 
-    def test_pre_produce(self):
+    @mock.patch("sorting_hat_step.utils.wizard.oid_query")
+    def test_pre_produce(self, mock_query):
+        mock_query.return_value = "aid"
         self.step.producer = mock.MagicMock(KafkaProducer)
         alerts = generate_alerts_batch(100)
         parsed = self.step.parser.parse(alerts)

--- a/tests/unittest/test_wizard.py
+++ b/tests/unittest/test_wizard.py
@@ -72,9 +72,9 @@ class SortingHatTestCase(unittest.TestCase):
     def test_find_existing_id(self, mock_query):
         alerts = pd.DataFrame(
             [
-                {"oid": "A", "tmp_id": "X"},
-                {"oid": "B", "tmp_id": "X"},
-                {"oid": "C", "tmp_id": "Y"},
+                {"oid": "A", "tmp_id": "X", "aid": None},
+                {"oid": "B", "tmp_id": "X", "aid": None},
+                {"oid": "C", "tmp_id": "Y", "aid": None},
             ]
         )
         mock_query.side_effect = ["aid1", None]


### PR DESCRIPTION
From MongoDB the AID is expected to be in the field `_id`.

Includes also simplifications and fixes to id finders and generators. 